### PR TITLE
Fix simple Gradio case and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# This is a sample Dockefile that builds a runtime container and runs the sample Gradio app.
+# Note, you must pass in the pretrained models when you run the container.
+
+FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04
+
+WORKDIR /workspace
+
+ADD . .
+
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        python3 \
+        python-is-python3 \
+        python3-pip \
+        libgl1 \
+        libgl1-mesa-glx \ 
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Who needs conda?
+
+RUN pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117 && \
+    pip install -r requirements.txt
+
+CMD "python scripts/interface.py --port=12345"
+
+# Build with
+# docker build . -t pixart
+
+# Run with 
+# docker run --gpus all -it -p 12345:12345 -v <path_to_models>:/workspace/output/pretrained_models pixart

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04
 
 WORKDIR /workspace
 
-ADD . .
-
 RUN apt-get update && \
     apt-get install -y \
         git \
@@ -18,12 +16,14 @@ RUN apt-get update && \
         libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Who needs conda?
+ADD requirements.txt .
 
 RUN pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117 && \
     pip install -r requirements.txt
 
-CMD "python scripts/interface.py --port=12345"
+ADD . .
+
+CMD ["/usr/bin/python", "/workspace/scripts/interface.py" ,"--port=12345", "--t5_path", "output/pretrained_models", "--model_path", "output/pretrained_models/PixArt-XL-2-1024-MS.pth"]
 
 # Build with
 # docker build . -t pixart

--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ Currently support:
 
 ## 1. Quick start with [Gradio](https://www.gradio.app/guides/quickstart)
 
-To get started, first install the required dependencies, then run on your local machine:
+To get started, first install the required dependencies. Also make sure you've downloaded the [models](https://huggingface.co/PixArt-alpha/PixArt-alpha) to the output/pretrained_models folder, and then run on your local machine:
 
 ```bash
-python scripts/interface.py --model_path path/to/model.pth --image_size=1024 --port=12345
+python scripts/interface.py --port=12345
 ```
 Let's have a look at a simple example using the `http://your-server-ip:12345`.
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,19 @@ Currently support:
 
 ## 1. Quick start with [Gradio](https://www.gradio.app/guides/quickstart)
 
-To get started, first install the required dependencies. Also make sure you've downloaded the [models](https://huggingface.co/PixArt-alpha/PixArt-alpha) to the output/pretrained_models folder, and then run on your local machine:
+To get started, first install the required dependencies. Make sure you've downloaded the [models](https://huggingface.co/PixArt-alpha/PixArt-alpha) to the output/pretrained_models folder, and then run on your local machine:
 
 ```bash
 python scripts/interface.py --port=12345
 ```
+
+As an alternative, a sample [Dockerfile](Dockerfile) is provided to make a runtime container that starts the Gradio app.
+
+```bash
+docker build . -t pixart
+docker run --gpus all -it -p 12345:12345 -v <path_to_models>:/workspace/output/pretrained_models pixart
+```
+
 Let's have a look at a simple example using the `http://your-server-ip:12345`.
 
 

--- a/scripts/interface.py
+++ b/scripts/interface.py
@@ -24,7 +24,7 @@ from asset.examples import examples
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--image_size', default=1024, type=int)
-    parser.add_argument('--model_path', default='output/pretrained_models/PixArt-XL-2-1024x1024.pth', type=str)
+    parser.add_argument('--model_path', default='output/pretrained_models/PixArt-XL-2-1024-MS.pth', type=str)
     parser.add_argument('--t5_path', default='output/pretrained_models', type=str)
     parser.add_argument('--tokenizer_path', default='output/pretrained_models/sd-vae-ft-ema', type=str)
     parser.add_argument('--llm_model', default='t5', type=str)

--- a/scripts/interface.py
+++ b/scripts/interface.py
@@ -25,7 +25,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--image_size', default=1024, type=int)
     parser.add_argument('--model_path', default='output/pretrained_models/PixArt-XL-2-1024x1024.pth', type=str)
-    parser.add_argument('--t5_path', default='output/pretrained_models/t5_ckpts', type=str)
+    parser.add_argument('--t5_path', default='output/pretrained_models', type=str)
     parser.add_argument('--tokenizer_path', default='output/pretrained_models/sd-vae-ft-ema', type=str)
     parser.add_argument('--llm_model', default='t5', type=str)
     parser.add_argument('--port', default=7788, type=int)


### PR DESCRIPTION
The current version of the pretrained models folder does not follow the same folder structure expected by the defaults in the Gradio script `interface.py` so since this is the simple / quick and easy path I adjusted the script to follow the model folder structure. I also renamed the default model in the script to match what's provided in the pretrained models.

I also removed some parameters from the examples. `--image_size=1024` is the default anyway, and `--model_path` also has a perfectly good default value now so I removed it for clarity.

I also added a sample Dockerfile for a Gradio runtime environment :)

Finally, I clarified where you need to place the pretrained models relative to everything else in order for the Gradio script to run properly!