### PR TITLE
Make it possible to specify which Pixart model to load (or all)

### DIFF
--- a/tools/download.py
+++ b/tools/download.py
@@ -10,6 +10,7 @@ Functions for downloading pre-trained PixArt models
 from torchvision.datasets.utils import download_url
 import torch
 import os
+import argparse
 
 
 pretrained_models = {'PixArt-XL-2-512x512.pth', 'PixArt-XL-2-1024x1024.pth'}
@@ -64,8 +65,14 @@ def download_other(model_name, model_zoo, output_dir):
 
 
 if __name__ == "__main__":
-    # Download all PixArt checkpoints
-    for model in pretrained_models:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model_names', nargs='+', type=str, default=pretrained_models)
+    args = parser.parse_args()
+    model_names = args.model_names
+    model_names = set(model_names)
+
+    # Download PixArt checkpoints
+    for model in model_names:
         download_model(model)    # for vae_model in vae_models:
     for vae_model in vae_models:
         download_other(vae_model, vae_models, 'output/pretrained_models/')


### PR DESCRIPTION
Examples:
To download all: `python PixArt-alpha/tools/download.py` To download just 512x512: `python PixArt-alpha/tools/download.py --model_names "PixArt-XL-2-512x512.pth"