### PR TITLE
Fix some mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Detailed **inference speed** and **code guidance** can be found in [docs](asset/
 
 ---
 ## 🚩 **New Features/Updates**
-- ✅ Feb. 07, 2023. [train_diffusers.py](train_scripts/train_diffusers.py) can directly train with diffusers model and visualize during training.
+- ✅ Feb. 07, 2024. [train_diffusers.py](train_scripts/train_diffusers.py) can directly train with diffusers model and visualize during training.
 - ✅ Jan. 26, 2024. 💥 All checkpoints of [PixArt-α](https://github.com/PixArt-alpha/PixArt-alpha), including 256px checkpoints are all available here [Download Models](#-download-models).
 - ✅ Jan. 19, 2024. 💥 [PixArt-δ](https://arxiv.org/abs/2401.05252) ControlNet [app_controlnet.py](app/app_controlnet.py) and [Checkpoint](https://huggingface.co/PixArt-alpha/PixArt-ControlNet/tree/main) is released!!!
 - ✅ Jan. 12, 2024. 💥 We release the [SAM-LLaVA-Captions](https://huggingface.co/datasets/PixArt-alpha/SAM-LLaVA-Captions10M) used in PixArt-α training.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For cards with a lot of capacity, such as A100, performance increases significan
 - Python >= 3.9 (Recommend to use [Anaconda](https://www.anaconda.com/download/#linux) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html))
 - [PyTorch >= 1.13.0+cu11.7](https://pytorch.org/)
 ```bash
-conda create -n pixart python==3.9.0
+conda create -n pixart python=3.9
 conda activate pixart
 pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu118
 


### PR DESCRIPTION
1. Fix some typos in the documentation: Feb. 07, 2023 -> Feb. 07, 2024.
2. The previous installation instruction `conda create -n pixart python==3.9.0` will cause `PackagesNotFoundError`. Use `conda create -n pixart python=3.9` will work.